### PR TITLE
fix:package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "plugin-hedera",
+  "name": "@elizaos/plugin-hedera",
   "description": "ElizaOS plugin for Hedera blockchain",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed npm package to the scoped name @elizaos/plugin-hedera.
  * Bumped version to 3.0.1.
  * No functional or API changes; behavior remains unchanged.
  * Users should update dependencies from plugin-hedera to @elizaos/plugin-hedera to receive future updates.
  * Existing installs will not auto-migrate; refresh lockfiles and reinstall to apply the new package name and version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->